### PR TITLE
bug fix: db corruption and wrong anonymization parameter

### DIFF
--- a/src/anonymized_data/transactions.py
+++ b/src/anonymized_data/transactions.py
@@ -15,7 +15,7 @@ class Transactions:
         self.table = df[output_columns]
 
     def sanitize_rare_combinations(self,df):
-        minimum_unique_users_per_combination = 2
+        minimum_unique_users_per_combination = 3
         df['distinct_users'] = pd.to_numeric(df['distinct_users'], errors='coerce')
         unusual_combinations_mask = df['distinct_users'] < minimum_unique_users_per_combination
         df.loc[unusual_combinations_mask, 'barcode_prod'] = PRODUCT_SANITIEZED_STR

--- a/src/tables/prod_table.py
+++ b/src/tables/prod_table.py
@@ -144,7 +144,7 @@ def open_stock(trigger_open, trigger_close, inps):
         return True, no_update
     if trigger == "confirm_new_stock":
         prods = get_prods()
-        if list(inps) == [None]:
+        if None in inps or any(int(a) < 0 for a in inps): #While current stock can become negative, if someone scans too much, i don't think you would ever set it as negative.
             return no_update
         prods["current_stock"] =[str(val) for val in list(inps)]
         upload_values(prods, "prods")

--- a/src/tables/prod_table.py
+++ b/src/tables/prod_table.py
@@ -144,7 +144,9 @@ def open_stock(trigger_open, trigger_close, inps):
         return True, no_update
     if trigger == "confirm_new_stock":
         prods = get_prods()
-        prods["current_stock"] = list(inps)
+        if list(inps) == [None]:
+            return no_update
+        prods["current_stock"] =[str(val) for val in list(inps)]
         upload_values(prods, "prods")
         waste = calculate_waste()
         update_values(waste=waste)


### PR DESCRIPTION
I fixed a parameter for anonymized data export, so it is in line with documentation approved by KABS.

Updating current stock so it is larger than initial stock would make the application crash next time it was started.
This is fixed by not reacting to illegal updates. Also added that you can't update current stock so it becomes negative, though it still of course can happen if people double scan their beverages.